### PR TITLE
Migrate to btcpay-python

### DIFF
--- a/pretix_bitpay/__init__.py
+++ b/pretix_bitpay/__init__.py
@@ -10,9 +10,9 @@ class BitpayApp(AppConfig):
     class PretixPluginMeta:
         name = _("BitPay")
         author = "Raphael Michel"
-        version = '1.1.0'
+        version = '1.2.0'
         description = _("This plugin allows you to receive Bitcoin payments " +
-                        "via BitPay")
+                        "via BitPay-compatible payment providers.")
 
     def ready(self):
         from . import signals   # NOQA
@@ -21,9 +21,9 @@ class BitpayApp(AppConfig):
     def compatibility_errors(self):
         errs = []
         try:
-            import bitpay  # NOQA
+            import btcpay  # NOQA
         except ImportError:
-            errs.append("Python package 'bitpay' is not installed.")
+            errs.append("Python package 'btcpay' is not installed.")
         return errs
 
 

--- a/pretix_bitpay/views.py
+++ b/pretix_bitpay/views.py
@@ -4,7 +4,7 @@ import logging
 from decimal import Decimal
 
 import requests
-from bitpay import key_utils
+from btcpay import crypto
 from django.conf import settings
 from django.contrib import messages
 from django.core import signing
@@ -197,9 +197,9 @@ def auth_start(request, **kwargs):
     pem = request.event.settings.payment_bitpay_pem
     if not pem:
         gs = GlobalSettingsObject()
-        pem = gs.settings.payment_bitpay_pem = key_utils.generate_pem()
+        pem = gs.settings.payment_bitpay_pem = crypto.generate_privkey()
 
-    sin = key_utils.get_sin_from_pem(pem)
+    sin = crypto.get_sin_from_pem(pem)
     if request.GET.get('url'):
         url = request.GET.get('url')
     else:

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,16 @@ cmdclass = {
 
 setup(
     name='pretix-bitpay',
-    version='1.1.0',
-    description='This plugin allows accepting crypto currency payments in pretix via BitPay.',
+    version='1.2.0',
+    description='This plugin allows accepting crypto currency payments in pretix via BitPay-compatible payment '
+                'providers.',
     long_description=long_description,
     url='https://github.com/pretix/pretix-bitpay',
     author='Raphael Michel',
     author_email='michel@rami.io',
     license='Apache Software License',
 
-    install_requires=['bitpay'],
+    install_requires=['btcpay-python'],
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     cmdclass=cmdclass,


### PR DESCRIPTION
Instead of vendoring the bitpay-client, we can also just switch over to `btcpay-python`, which can already retrieve invoices from the merchant facade and works with BitPay and BTCPayServer without screwing around with particularities.

Quick test with BitPay and BTCPay testnet-accounts were successful and existing tokens and pems can be reused.