### PR TITLE
Rename Bitcoin to crypto

### DIFF
--- a/pretix_bitpay/__init__.py
+++ b/pretix_bitpay/__init__.py
@@ -12,7 +12,7 @@ class BitpayApp(AppConfig):
         author = "Raphael Michel"
         category = 'PAYMENT'
         version = '1.4.1'
-        description = _("This plugin allows you to receive Bitcoin payments " +
+        description = _("This plugin allows you to receive Crypto payments " +
                         "via BitPay-compatible payment providers.")
 
     def ready(self):

--- a/pretix_bitpay/__init__.py
+++ b/pretix_bitpay/__init__.py
@@ -11,7 +11,7 @@ class BitpayApp(AppConfig):
         name = _("BitPay")
         author = "Raphael Michel"
         category = 'PAYMENT'
-        version = '1.4.1'
+        version = '1.4.2'
         description = _("This plugin allows you to receive Crypto payments " +
                         "via BitPay-compatible payment providers.")
 

--- a/pretix_bitpay/locale/ar/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/ar/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/ca/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/ca/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/cs/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/cs/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/da/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/da/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/de/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/de/LC_MESSAGES/django.po
@@ -20,12 +20,12 @@ msgid "BitPay"
 msgstr "BitPay"
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
-msgstr "Dieses Plugin erlaubt, Bitcoin-Zahlungen über BitPay zu empfangen"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
+msgstr "Dieses Plugin erlaubt, Crypto-Zahlungen über BitPay zu empfangen"
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
-msgstr "Bitcoin"
+msgid "Crypto"
+msgstr "Crypto"
 
 #: pretix_bitpay/payment.py:49
 msgid ""

--- a/pretix_bitpay/locale/de_Informal/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/de_Informal/LC_MESSAGES/django.po
@@ -20,12 +20,12 @@ msgid "BitPay"
 msgstr "BitPay"
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
-msgstr "Dieses Plugin erlaubt, Bitcoin-Zahlungen über BitPay zu empfangen"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
+msgstr "Dieses Plugin erlaubt, Crypto-Zahlungen über BitPay zu empfangen"
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
-msgstr "Bitcoin"
+msgid "Crypto"
+msgstr "Crypto"
 
 #: pretix_bitpay/payment.py:49
 msgid ""

--- a/pretix_bitpay/locale/django.pot
+++ b/pretix_bitpay/locale/django.pot
@@ -23,11 +23,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/el/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/el/LC_MESSAGES/django.po
@@ -25,13 +25,13 @@ msgid "BitPay"
 msgstr "BitPay"
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
-"Αυτό το plugin σάς επιτρέπει να λαμβάνετε πληρωμές Bitcoin μέσω του BitPay"
+"Αυτό το plugin σάς επιτρέπει να λαμβάνετε πληρωμές Crypto μέσω του BitPay"
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
-msgstr "Bitcoin"
+msgid "Crypto"
+msgstr "Crypto"
 
 #: pretix_bitpay/payment.py:49
 msgid ""

--- a/pretix_bitpay/locale/es/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/es/LC_MESSAGES/django.po
@@ -25,12 +25,12 @@ msgid "BitPay"
 msgstr "BitPay"
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
-msgstr "Este plugin te permite recibir pagos con Bitcoin a través de BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
+msgstr "Este plugin te permite recibir pagos con Crypto a través de BitPay"
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
-msgstr "Bitcoin"
+msgid "Crypto"
+msgstr "Crypto"
 
 #: pretix_bitpay/payment.py:49
 msgid ""

--- a/pretix_bitpay/locale/fr/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/fr/LC_MESSAGES/django.po
@@ -25,12 +25,12 @@ msgid "BitPay"
 msgstr "BitPay"
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
-msgstr "Ce plugin vous permet de recevoir les paiements en Bitcoin via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
+msgstr "Ce plugin vous permet de recevoir les paiements en Crypto via BitPay"
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
-msgstr "Bitcoin"
+msgid "Crypto"
+msgstr "Crypto"
 
 #: pretix_bitpay/payment.py:49
 msgid ""

--- a/pretix_bitpay/locale/it/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/it/LC_MESSAGES/django.po
@@ -25,11 +25,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/lv/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/lv/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/nl/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/nl/LC_MESSAGES/django.po
@@ -20,12 +20,12 @@ msgid "BitPay"
 msgstr "BitPay"
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
-msgstr "Deze plug-in staat u toe om Bitcoin-betalingen te ontvangen via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
+msgstr "Deze plug-in staat u toe om Crypto-betalingen te ontvangen via BitPay"
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
-msgstr "Bitcoin"
+msgid "Crypto"
+msgstr "Crypto"
 
 #: pretix_bitpay/payment.py:49
 msgid ""

--- a/pretix_bitpay/locale/nl_BE/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/nl_BE/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/nl_Informal/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/nl_Informal/LC_MESSAGES/django.po
@@ -25,12 +25,12 @@ msgid "BitPay"
 msgstr "BitPay"
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
-msgstr "Deze plug-in staat je toe om Bitcoin-betalingen te ontvangen via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
+msgstr "Deze plug-in staat je toe om Crypto-betalingen te ontvangen via BitPay"
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
-msgstr "Bitcoin"
+msgid "Crypto"
+msgstr "Crypto"
 
 #: pretix_bitpay/payment.py:49
 msgid ""

--- a/pretix_bitpay/locale/pl/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/pl/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/pl_Informal/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/pl_Informal/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/pt_BR/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/pt_BR/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/ru/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/ru/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/sl/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/sl/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/sv/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/sv/LC_MESSAGES/django.po
@@ -22,11 +22,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/locale/tr/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/tr/LC_MESSAGES/django.po
@@ -25,12 +25,12 @@ msgid "BitPay"
 msgstr "Bitpay"
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
-msgstr "Bu eklenti BitPay üzerinden Bitcoin ödemeleri almanızı sağlar."
+msgid "This plugin allows you to receive Crypto payments via BitPay"
+msgstr "Bu eklenti BitPay üzerinden Crypto ödemeleri almanızı sağlar."
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
-msgstr "Bitcoin"
+msgid "Crypto"
+msgstr "Crypto"
 
 #: pretix_bitpay/payment.py:49
 msgid ""

--- a/pretix_bitpay/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/pretix_bitpay/locale/zh_Hans/LC_MESSAGES/django.po
@@ -25,11 +25,11 @@ msgid "BitPay"
 msgstr ""
 
 #: pretix_bitpay/__init__.py:14
-msgid "This plugin allows you to receive Bitcoin payments via BitPay"
+msgid "This plugin allows you to receive Crypto payments via BitPay"
 msgstr ""
 
 #: pretix_bitpay/payment.py:31
-msgid "Bitcoin"
+msgid "Crypto"
 msgstr ""
 
 #: pretix_bitpay/payment.py:49

--- a/pretix_bitpay/payment.py
+++ b/pretix_bitpay/payment.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class BitPay(BasePaymentProvider):
     identifier = 'bitpay'
     verbose_name = _('BitPay')
-    public_name = _('Bitcoin')
+    public_name = _('Crypto')
 
     def settings_content_render(self, request):
         if not self.settings.token:


### PR DESCRIPTION
As discussed on #12 

I think 'Crypto' would be a better term as Bitpay is flexible and accepts a wide range of cryptocurrencies. Not just Bitcoin.